### PR TITLE
Next release. API Parity and documentation improvement. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 }
 
-def jarVersion = "1.2.0-beta14"
+def jarVersion = "1.3.0-beta15"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
 
-    implementation 'io.nats:jnats:2.16.8'
+    implementation 'io.nats:jnats:2.16.10'
     implementation("com.fasterxml.jackson.core:jackson-core:2.14.2")
     implementation("io.netty:netty-handler:4.1.89.Final")
     implementation(platform("io.vertx:vertx-stack-depchain:4.4.0"))

--- a/src/main/java/io/nats/vertx/NatsClient.java
+++ b/src/main/java/io/nats/vertx/NatsClient.java
@@ -203,4 +203,13 @@ public interface NatsClient extends WriteStream<Message> {
      * @return Low level NATS connection.
      */
     Connection getConnection();
+
+    Future<Void> close();
+
+    @Override
+    default Future<Void> end() {
+        return close();
+    }
+
+
 }

--- a/src/main/java/io/nats/vertx/NatsClient.java
+++ b/src/main/java/io/nats/vertx/NatsClient.java
@@ -2,6 +2,7 @@ package io.nats.vertx;
 
 
 import io.nats.client.*;
+import io.nats.client.impl.Headers;
 import io.nats.vertx.impl.NatsClientImpl;
 import io.vertx.core.*;
 import io.vertx.core.streams.WriteStream;
@@ -137,6 +138,33 @@ public interface NatsClient extends WriteStream<Message> {
     Future<Message> request(String subject, byte[] message);
 
 
+
+
+    /**
+     * Send a request. The returned future will be completed when the
+     * response comes back.
+     *
+     * @param subject the subject for the service that will handle the request
+     * @param headers Optional headers to publish with the message.
+     * @param body the content of the message
+     * @return a Future for the response, which may be cancelled on error or timed out
+     */
+    Future<Message> request(String subject, Headers headers, byte[] body);
+
+
+    /**
+     * Send a request. The returned future will be completed when the
+     * response comes back.
+     *
+     * @param subject the subject for the service that will handle the request
+     * @param body the content of the message
+     * @param headers Optional headers to publish with the message.
+     * @param timeout the time to wait for a response
+     * @return a Future for the response, which may be cancelled on error or timed out
+     */
+    Future<Message> requestWithTimeout(String subject, Headers headers, byte[] body, Duration timeout);
+
+
     /**
      *
      * Send request.
@@ -171,6 +199,57 @@ public interface NatsClient extends WriteStream<Message> {
      */
     Future<Message> request(String subject, byte[] message, Duration timeout);
 
+
+    /**
+     * Send a message to the specified subject. The message body <strong>will
+     * not</strong> be copied. The expected usage with string content is something
+     * like:
+     *
+     * <pre>
+     *
+     * Headers h = new Headers().put("key", "value");
+     * var future = nc.publish("destination", h, "message".getBytes("UTF-8"))
+     * </pre>
+     *
+     * where the sender creates a byte array immediately before calling publish.
+     *
+     * See {@link #publish(String, String, byte[]) publish()} for more details on
+     * publish during reconnect.
+     *
+     * @param subject the subject to send the message to
+     * @param headers Optional headers to publish with the message.
+     * @param body the message body
+     * @throws IllegalStateException if the reconnect buffer is exceeded
+     */
+    Future<Void> publish(String subject, Headers headers, byte[] body);
+
+    /**
+     * Send a request to the specified subject, providing a replyTo subject. The
+     * message body <strong>will not</strong> be copied. The expected usage with
+     * string content is something like:
+     *
+     * <pre>
+     * nc = Nats.connect()
+     * Headers h = new Headers().put("key", "value");
+     * var future = nc.publish("destination", "reply-to", h, "message".getBytes("UTF-8"))
+     * </pre>
+     *
+     * where the sender creates a byte array immediately before calling publish.
+     * <p>
+     * During reconnect the client will try to buffer messages. The buffer size is set
+     * in the connect options, see {@link Options.Builder#reconnectBufferSize(long) reconnectBufferSize()}
+     * with a default value of {@link Options#DEFAULT_RECONNECT_BUF_SIZE 8 * 1024 * 1024} bytes.
+     * If the buffer is exceeded an IllegalStateException is thrown. Applications should use
+     * this exception as a signal to wait for reconnect before continuing.
+     * </p>
+     * @param subject the subject to send the message to
+     * @param replyTo the subject the receiver should send the response to
+     * @param headers Optional headers to publish with the message.
+     * @param body the message body
+     * @throws IllegalStateException if the reconnect buffer is exceeded
+     */
+    Future<Void> publish(String subject, String replyTo, Headers headers, byte[] body);
+
     /**
      *
      * Subscribe to subject.
@@ -179,6 +258,7 @@ public interface NatsClient extends WriteStream<Message> {
      * @return future to know results of the subscribe operation.
      */
     Future<Void> subscribe(String subject, Handler<Message> handler);
+
 
     /**
      *

--- a/src/main/java/io/nats/vertx/NatsStream.java
+++ b/src/main/java/io/nats/vertx/NatsStream.java
@@ -3,6 +3,7 @@ package io.nats.vertx;
 
 import io.nats.client.*;
 import io.nats.client.api.PublishAck;
+import io.nats.client.impl.Headers;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -165,4 +166,58 @@ public interface NatsStream extends WriteStream<Message> {
      * @return  future returning the results of the publish operation.
      */
     Future<PublishAck> publish(Message data, PublishOptions options);
+
+
+    /**
+     * Send a message to the specified subject and waits for a response from
+     * Jetstream. The default publish options will be used.
+     * The message body <strong>will not</strong> be copied. The expected
+     * usage with string content is something like:
+     *
+     * <pre>
+     * nc = Nats.connect()
+     * JetStream js = nc.JetStream()
+     * Headers h = new Headers().put("foo", "bar");
+     * js.publish("destination", h, "message".getBytes("UTF-8"))
+     * </pre>
+     *
+     * where the sender creates a byte array immediately before calling publish.
+     *
+     * See {@link #publish(String, byte[]) publish()} for more details on
+     * publish during reconnect.
+     *
+     * @param subject the subject to send the message to
+     * @param headers Optional headers to publish with the message.
+     * @param body the message body
+     * @return The ack.
+     */
+    Future<PublishAck> publish(String subject, Headers headers, byte[] body);
+
+
+    /**
+     * Send a message to the specified subject and waits for a response from
+     * Jetstream. The message body <strong>will not</strong> be copied. The expected
+     * usage with string content is something like:
+     *
+     * <pre>
+     * nc = Nats.connect()
+     * JetStream js = nc.JetStream()
+     * Headers h = new Headers().put("foo", "bar");
+     * js.publish("destination", h, "message".getBytes("UTF-8"), publishOptions)
+     * </pre>
+     *
+     * where the sender creates a byte array immediately before calling publish.
+     *
+     * See {@link #publish(String, byte[]) publish()} for more details on
+     * publish during reconnect.
+     *
+     * @param subject the subject to send the message to
+     * @param headers Optional headers to publish with the message.
+     * @param body the message body
+     * @param options publisher options
+     * @return The ack.
+     */
+    Future<PublishAck> publish(String subject, Headers headers, byte[] body, PublishOptions options);
+
+
 }

--- a/src/main/java/io/nats/vertx/impl/NatsClientImpl.java
+++ b/src/main/java/io/nats/vertx/impl/NatsClientImpl.java
@@ -483,4 +483,18 @@ public class NatsClientImpl implements NatsClient {
     public Connection getConnection() {
         return this.connection.get();
     }
+
+    @Override
+    public Future<Void> close() {
+        final Promise<Void> promise = context().promise();
+        context().executeBlocking(event -> {
+            try {
+              getConnection().close();
+              promise.complete();
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
 }

--- a/src/main/java/io/nats/vertx/impl/NatsClientImpl.java
+++ b/src/main/java/io/nats/vertx/impl/NatsClientImpl.java
@@ -1,6 +1,7 @@
 package io.nats.vertx.impl;
 
 import io.nats.client.*;
+import io.nats.client.impl.Headers;
 import io.nats.vertx.NatsClient;
 import io.nats.vertx.NatsOptions;
 import io.nats.vertx.NatsStream;
@@ -359,6 +360,32 @@ public class NatsClientImpl implements NatsClient {
     }
 
     @Override
+    public Future<Message> request(final String subject, final Headers headers, final byte[] body) {
+        return context().executeBlocking(event -> {
+            try {
+                final CompletableFuture<Message> request = connection.get().request(subject, headers, body);
+                final Message result = request.get();
+                event.complete(result);
+            } catch (Exception e) {
+                handleException(event, e);
+            }
+        }, false);
+    }
+
+    @Override
+    public Future<Message> requestWithTimeout(String subject, Headers headers, byte[] body, Duration timeout) {
+        return context().executeBlocking(event -> {
+            try {
+                final CompletableFuture<Message> request = connection.get().requestWithTimeout(subject, headers, body, timeout);
+                final Message result = request.get();
+                event.complete(result);
+            } catch (Exception e) {
+                handleException(event, e);
+            }
+        }, false);
+    }
+
+    @Override
     public void request(final Message data, final Handler<AsyncResult<Message>> handler, final Duration timeout) {
         final Promise<Message> promise = context().promise();
         context().executeBlocking((Handler<Promise<Void>>) event -> {
@@ -407,6 +434,35 @@ public class NatsClientImpl implements NatsClient {
     }
 
     @Override
+    public Future<Void> publish(String subject, Headers headers, byte[] body) {
+        final Promise<Void> promise = context().promise();
+        context().executeBlocking(event -> {
+            try {
+                connection.get().publish(subject, headers, body);
+                promise.complete();
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
+    public Future<Void> publish(final String subject, final String replyTo, final Headers headers, final byte[] body) {
+
+        final Promise<Void> promise = context().promise();
+        context().executeBlocking(event -> {
+            try {
+                connection.get().publish(subject, replyTo, headers, body);
+                promise.complete();
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
     public Future<Void> subscribe(String subject, Handler<Message> handler) {
 
         final Promise<Void> promise = context().promise();
@@ -427,9 +483,7 @@ public class NatsClientImpl implements NatsClient {
     private void drainSubscription(Handler<Message> handler, final Subscription subscribe, final String subject) {
         try {
             Message message = subscribe.nextMessage(noWait);
-            int count = 0;
             while (message!=null) {
-                count++;
                 try {
                     handler.handle(message);
                 } catch (Exception e) {
@@ -437,8 +491,9 @@ public class NatsClientImpl implements NatsClient {
                 }
                 message = subscribe.nextMessage(noWait);
             }
-            if (subscriptionMap.containsKey(subject))
-            context().setTimer(100, event -> context().executeBlocking(e -> drainSubscription(handler, subscribe, subject), false));
+            if (subscriptionMap.containsKey(subject)) {
+                context().setTimer(100, event -> context().executeBlocking(e -> drainSubscription(handler, subscribe, subject), false));
+            }
         } catch (Exception e) {
             exceptionHandler.get().handle(e);
         }

--- a/src/main/java/io/nats/vertx/impl/NatsStreamImpl.java
+++ b/src/main/java/io/nats/vertx/impl/NatsStreamImpl.java
@@ -2,6 +2,7 @@ package io.nats.vertx.impl;
 
 import io.nats.client.*;
 import io.nats.client.api.PublishAck;
+import io.nats.client.impl.Headers;
 import io.nats.vertx.NatsStream;
 import io.nats.vertx.NatsVertxMessage;
 import io.vertx.core.*;
@@ -164,6 +165,34 @@ public class NatsStreamImpl implements NatsStream {
         context().executeBlocking(event -> {
             try {
                 final PublishAck ack = jetStream.publish(data, options);
+                promise.complete(ack);
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
+    public Future<PublishAck> publish(String subject, Headers headers, byte[] body) {
+        final Promise<PublishAck> promise = context().promise();
+        context().executeBlocking(event -> {
+            try {
+                final PublishAck ack = jetStream.publish(subject, headers, body);
+                promise.complete(ack);
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
+    public Future<PublishAck> publish(String subject, Headers headers, byte[] body, PublishOptions options) {
+        final Promise<PublishAck> promise = context().promise();
+        context().executeBlocking(event -> {
+            try {
+                final PublishAck ack = jetStream.publish(subject, headers, body, options);
                 promise.complete(ack);
             } catch (Exception e) {
                 handleException(promise, e);


### PR DESCRIPTION
# Release Notes for `nats-java-vertx-client` v1.3.0-beta15

The `nats-java-vertx-client` is a Java client library for the NATS messaging system that uses the Vert.x interface. This release includes new features, enhancements, and bug fixes.

## Changes
*  #43 don't see a close() on the NATS Vert.x client that would map to the NATS client close
* #46 method request/publish(Message data) supports headers in both NatsClient and Stream. Nice to have other methods supporting headers too
* Improved code coverage #37 but more work to be done.
* Updated to support version 'io.nats:jnats:2.16.10' of client lib.
* Added support for in-progress and term message acknowledgments.
* Added asynchronous versions of message acknowledgment methods.
* Added documentation for pull subscribing.
* Added support for publishing and subscribing to JetStream-enabled servers.
* Added support for JetStream context creation.
* Added support for advanced publish options in JetStream.
* Added support for ordered push subscription option.
* Added NatsUtils class to create a stream or update stream subject if the stream exists.

## Enhancements
* Improved the readability of the code examples in the documentation.
* Improved the error handling of the client library.
* Improved the compatibility with the Vert.x event-driven framework.

## Bug Fixes
* Fixed a bug that caused the client library to fail when publishing messages with an empty data payload.

## Breaking Changes
* None

## Known Issues
* None at this time.
* Improvements are listed in Issues, but none are show-stoppers for this beta release.


## JetStreamClusterMain Test
A new JetStreamClusterMain.java test is included in the project, showcasing how to use JetStream with a cluster setup. The test connects to a NATS cluster consisting of three nodes, creates or looks up a stream, and starts a consumer and producer, publishing and consuming messages from the stream. It also displays statistics on the number of messages sent and received and any errors encountered.

The JetStreamClusterMain.java test demonstrates how to use the JetStream API to manage and use streams in a NATS cluster, and serves as a useful starting point for developers who want to create a high-availability messaging system using JetStream.