### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/build-merge-or-release.yml
+++ b/.github/workflows/build-merge-or-release.yml
@@ -1,4 +1,4 @@
-name: GitHub Merge Or Release Build Actions For Nats Server Runner
+name: GitHub Merge Or Release Build Actions For Vert.x NATS client
 
 on:
   push:

--- a/.github/workflows/build-merge-or-release.yml
+++ b/.github/workflows/build-merge-or-release.yml
@@ -21,14 +21,14 @@ jobs:
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -42,7 +42,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test
       - name: Verify Javadoc

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,4 +1,4 @@
-name: GitHub PR Build Actions For Nats Server Runner
+name: GitHub PR Build Actions For Vert.x NATS client
 
 on:
   pull_request:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,14 +11,14 @@ jobs:
       BUILD_EVENT: ${{ github.event_name }}
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -32,7 +32,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test
       - name: Verify Javadoc


### PR DESCRIPTION
Bump various GitHub Actions versions to move away from those using the deprecated node.js 12 runtime, and so remove the warnings.

Bump Golang to the latest security fixed patch-level within the same minor, and quote the string for defensiveness against version number parsing and YAML string vs version numbers.  While we're unlikely to switch to patch-level-unspecified in future, protect against mistakes by quoting, as we're doing for all repos.
