### PR TITLE
changed interface for pull subscription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 }
 
-def jarVersion = "1.3.0-beta15"
+def jarVersion = "2.0.0-beta16"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"

--- a/src/main/java/io/nats/vertx/NatsStream.java
+++ b/src/main/java/io/nats/vertx/NatsStream.java
@@ -183,4 +183,13 @@ public interface NatsStream extends WriteStream<Message> {
         return nextMessage(subject, 0);
     }
 
+
+    /**
+     * Request to pull a batch of message from the subscription.
+     * You need to call nextMessage after this to get the messages.
+     * @param subject subject The subject for the subscription.
+     * @return future message.
+     */
+    Future<Void> pull(final String subject, final int batchSize);
+
 }

--- a/src/main/java/io/nats/vertx/NatsStream.java
+++ b/src/main/java/io/nats/vertx/NatsStream.java
@@ -1,6 +1,5 @@
 package io.nats.vertx;
 
-
 import io.nats.client.*;
 import io.nats.client.api.PublishAck;
 import io.nats.client.impl.Headers;
@@ -8,9 +7,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.streams.WriteStream;
-
-import java.time.Duration;
-import java.util.List;
 
 /**
  * Provides a Vert.x WriteStream interface with Futures and Promises.
@@ -86,70 +82,20 @@ public interface NatsStream extends WriteStream<Message> {
     /**
      * Subscribe to JetStream stream
      * @param subject The subject of the stream.
-     * @param handler The message handler to listen to messages from the stream.
      * @param so The PullSubscribeOptions
-     * @return future that returns status of subscription.
-     */
-    default Future<Void> subscribe(
-            String subject, Handler<NatsVertxMessage> handler, PullSubscribeOptions so) {
-        return this.subscribe(subject, handler, so, 10);
-    }
-
-
-    /**
-     * Subscribe to JetStream stream
-     * @param subject The subject of the stream.
-     * @param handler The message handler to listen to messages from the stream.
-     * @param so The PullSubscribeOptions
-     * @param so The PullSubscribeOptions
-     *
      * @return future that returns status of subscription.
      */
     Future<Void> subscribe(
-            String subject, Handler<NatsVertxMessage> handler, PullSubscribeOptions so, int batchSize);
+            String subject, PullSubscribeOptions so) ;
 
 
     /**
      * Subscribe to JetStream stream
      * @param subject The subject of the stream.
-     * @param handler The message handler to listen to messages from the stream.
      * @return future that returns status of subscription.
      */
     Future<Void> subscribe(
-            String subject, Handler<NatsVertxMessage> handler);
-
-
-    /**
-     * Subscribe to JetStream stream
-     * @param subject The subject of the stream.
-     * @param handler The message handler to listen to messages from the stream.
-     * @param  batchSize Batch Size
-     * @param batchDuration Wait this long before returning what is in the batch.
-     * @param so The PullSubscribeOptions
-     *
-     * @return future that returns status of subscription.
-     */
-    Future<Void> subscribeBatch(
-            String subject, Handler<List<NatsVertxMessage>> handler, int batchSize, Duration batchDuration,
-            final PullSubscribeOptions so);
-
-
-    /**
-     * Subscribe to JetStream stream
-     * @param subject The subject of the stream.
-     * @param handler The message handler to listen to messages from the stream.
-     * @param  batchSize Batch Size
-     * @param batchDuration Wait this long before returning what is in the batch.
-     * @param so The PullSubscribeOptions
-     *
-     * @return future that returns status of subscription.
-     */
-    default Future<Void> subscribeWithBatch(
-            String subject, Handler<NatsVertxMessage> handler, int batchSize, Duration batchDuration,
-            final PullSubscribeOptions so) {
-        return subscribeBatch(subject, event -> event.forEach(handler::handle), batchSize, batchDuration, so);
-    }
-
+            String subject) ;
 
 
     /**
@@ -219,5 +165,22 @@ public interface NatsStream extends WriteStream<Message> {
      */
     Future<PublishAck> publish(String subject, Headers headers, byte[] body, PublishOptions options);
 
+
+    /**
+     * Retrieve a message from the subscription.
+     * @param subject subject The subject for the subscription.
+     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+     * @return future message.
+     */
+    Future<Message> nextMessage(final String subject, final int batchSize);
+
+    /**
+     * Retrieve a message from the subscription.
+     * @param subject subject The subject for the subscription.
+     * @return future message.
+     */
+    default  Future<Message> nextMessage(final String subject) {
+        return nextMessage(subject, 0);
+    }
 
 }

--- a/src/test/java/io/nats/vertx/NatsClientTest.java
+++ b/src/test/java/io/nats/vertx/NatsClientTest.java
@@ -735,7 +735,7 @@ public class NatsClientTest {
             }
         }
 
-        latch.await(3, TimeUnit.SECONDS);
+        latch.await(10, TimeUnit.SECONDS);
 
         natsClient.unsubscribe(SUBJECT_NAME);
 

--- a/src/test/java/io/nats/vertx/NatsStreamTest.java
+++ b/src/test/java/io/nats/vertx/NatsStreamTest.java
@@ -46,7 +46,7 @@ public class NatsStreamTest {
     @BeforeEach
     public void setup() throws Exception {
         natsServerRunner = new NatsServerRunner(0, false, true);
-        Thread.sleep(1);
+        Thread.sleep(200);
 
 
         port = natsServerRunner.getPort();
@@ -151,10 +151,6 @@ public class NatsStreamTest {
         final String data = "data";
 
         final JetStreamSubscription subscription = nc.jetStream().subscribe(SUBJECT_NAME);
-//
-//        natsStream.subscribe(SUBJECT_NAME, event -> {
-
-//        }, new PullSubscribeOptions.Builder().name("bob").durable("bob").stream(SUBJECT_NAME).build());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -188,147 +184,82 @@ public class NatsStreamTest {
 
     @Test
     public void testSubJetStreamWithPull() throws Exception {
-
-        final NatsClient natsClient = getNatsClient();
+        final AtomicInteger errorsFromHandler = new AtomicInteger();
+        final NatsClient natsClient = getNatsClient(event -> {
+            errorsFromHandler.incrementAndGet();
+        } );
         final NatsStream natsStream = getJetStream(natsClient);
-
         final CountDownLatch latch = new CountDownLatch(10);
         final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(20);
         final String data = "data";
-
-        natsStream.subscribe(SUBJECT_NAME, event -> {
-            event.message().ack();
-            queue.add(event.message());
-            latch.countDown();
-        });
-
-
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final Future<Void> subscribe = natsStream.subscribe(SUBJECT_NAME);
+        subscribe.onSuccess(event -> startLatch.countDown()).onFailure(event -> event.printStackTrace());
+        startLatch.await(10, TimeUnit.SECONDS);
+        System.out.println("Started subscription");
         for (int i = 0; i < 10; i++) {
             nc.publish(SUBJECT_NAME, (data + i).getBytes());
         }
-
-        latch.await(1, TimeUnit.SECONDS);
-
+        Thread.sleep(100);
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            for (int i = 0; i < 10; i++) {
+                final Future<Message> messageFuture = natsStream.nextMessage(SUBJECT_NAME);
+                messageFuture.onSuccess(event -> {
+                    latch.countDown();
+                    queue.add(event);
+                }).onFailure(event -> event.printStackTrace());
+            }
+        });
+        latch.await(10, TimeUnit.SECONDS);
         natsStream.unsubscribe(SUBJECT_NAME);
-        Thread.sleep(1000);
-
-
+        Thread.sleep(100);
         assertEquals(10, queue.size());
-
         closeClient(natsClient);
     }
 
 
     @Test
     public void testSubJetStreamWithPullOptions() throws Exception {
-
-        final NatsClient natsClient = getNatsClient();
+        final AtomicInteger errorsFromHandler = new AtomicInteger();
+        final NatsClient natsClient = getNatsClient(event -> {
+            errorsFromHandler.incrementAndGet();
+        } );
         final NatsStream natsStream = getJetStream(natsClient);
-
         final CountDownLatch latch = new CountDownLatch(10);
         final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(20);
         final String data = "data";
         final PullSubscribeOptions pullOptions = PullSubscribeOptions.builder()
                 .durable("durable-name-is-required")
                 .build();
-
-        natsStream.subscribe(SUBJECT_NAME, event -> {
-            event.message().ack();
-            queue.add(event.message());
-            latch.countDown();
-        }, pullOptions);
-
-
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final Future<Void> subscribe = natsStream.subscribe(SUBJECT_NAME, pullOptions);
+        subscribe.onSuccess(event -> startLatch.countDown()).onFailure(event -> event.printStackTrace());
+        startLatch.await(10, TimeUnit.SECONDS);
+        System.out.println("Started subscription");
         for (int i = 0; i < 10; i++) {
             nc.publish(SUBJECT_NAME, (data + i).getBytes());
         }
-
-        latch.await(1, TimeUnit.SECONDS);
-
+        Thread.sleep(100);
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            for (int i = 0; i < 10; i++) {
+                final Future<Message> messageFuture = natsStream.nextMessage(SUBJECT_NAME, 1);
+                messageFuture.onSuccess(event -> {
+                    latch.countDown();
+                    queue.add(event);
+                }).onFailure(event -> event.printStackTrace());
+            }
+        });
+        latch.await(10, TimeUnit.SECONDS);
         natsStream.unsubscribe(SUBJECT_NAME);
-        Thread.sleep(1000);
-
-
+        Thread.sleep(100);
         assertEquals(10, queue.size());
-
-        closeClient(natsClient);
-    }
-
-
-    @Test
-    public void testSubJetStreamWithPullBatch() throws Exception {
-
-        final NatsClient natsClient = getNatsClient();
-        final NatsStream natsStream = getJetStream(natsClient);
-
-        final CountDownLatch latch = new CountDownLatch(50);
-        final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(55);
-        final String data = "data";
-
-        final PullSubscribeOptions pullOptions = PullSubscribeOptions.builder()
-                .durable("durable-name-is-required")
-                .build();
-
-        natsStream.subscribeBatch(SUBJECT_NAME, messages -> {
-            messages.forEach(event -> {
-                        queue.add(event.message());
-                        latch.countDown();
-                    }
-            );
-        }, 10, Duration.ofMillis(10), pullOptions);
-
-
-        for (int i = 0; i < 50; i++) {
-            nc.publish(SUBJECT_NAME, (data + i).getBytes());
-        }
-
-        latch.await(1, TimeUnit.SECONDS);
-
-        natsStream.unsubscribe(SUBJECT_NAME);
-        Thread.sleep(1000);
-
-
-        assertEquals(50, queue.size());
-
         closeClient(natsClient);
     }
 
 
 
-    @Test
-    public void testSubJetStreamWithBatch() throws Exception {
-
-        final NatsClient natsClient = getNatsClient();
-        final NatsStream natsStream = getJetStream(natsClient);
-
-        final CountDownLatch latch = new CountDownLatch(50);
-        final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(55);
-        final String data = "data";
-
-        final PullSubscribeOptions pullOptions = PullSubscribeOptions.builder()
-                .durable("durable-name-is-required")
-                .build();
-
-        natsStream.subscribeWithBatch(SUBJECT_NAME, event -> {
-                        queue.add(event.message());
-                        latch.countDown();
-        }, 10, Duration.ofMillis(10), pullOptions);
-
-
-        for (int i = 0; i < 50; i++) {
-            nc.publish(SUBJECT_NAME, (data + i).getBytes());
-        }
-
-        latch.await(1, TimeUnit.SECONDS);
-
-        natsStream.unsubscribe(SUBJECT_NAME);
-        Thread.sleep(1000);
-
-
-        assertEquals(50, queue.size());
-
-        closeClient(natsClient);
-    }
 
     private NatsStream getJetStream(NatsClient natsClient) throws InterruptedException {
         final Future<NatsStream> connect = natsClient.jetStream();
@@ -417,7 +348,7 @@ public class NatsStreamTest {
             error.set(event);
             latch.countDown();
         });
-        latch.await(1, TimeUnit.SECONDS);
+        latch.await(10, TimeUnit.SECONDS);
         if (error.get() != null) {
             throw new IllegalStateException(error.get());
         }
@@ -932,13 +863,13 @@ public class NatsStreamTest {
 
 
             if (i == 4) {
-                Thread.sleep(1000);
+                Thread.sleep(100);
                 natsServerRunner.close();
-                Thread.sleep(1000);
+                Thread.sleep(100);
             }
         }
 
-        Thread.sleep(200);
+        Thread.sleep(100);
         receiveLatch.await(1, TimeUnit.SECONDS);
         errorsLatch.await(10, TimeUnit.SECONDS);
 
@@ -1005,13 +936,13 @@ public class NatsStreamTest {
 
 
             if (i == 4) {
-                Thread.sleep(1000);
+                Thread.sleep(100);
                 natsServerRunner.close();
-                Thread.sleep(1000);
+                Thread.sleep(100);
             }
         }
 
-        Thread.sleep(1000);
+        Thread.sleep(100);
         receiveLatch.await(10, TimeUnit.SECONDS);
         errorsLatch.await(10, TimeUnit.SECONDS);
 

--- a/src/test/java/io/nats/vertx/NatsStreamTest.java
+++ b/src/test/java/io/nats/vertx/NatsStreamTest.java
@@ -964,16 +964,15 @@ public class NatsStreamTest {
             }
         }
 
-        Thread.sleep(100);
+        Thread.sleep(1000);
         receiveLatch.await(10, TimeUnit.SECONDS);
         errorsLatch.await(10, TimeUnit.SECONDS);
 
         assertEquals(5, queue.size());
 
         assertTrue(errorsFromHandler.get() >= 5);
-        assertEquals(5, sends.get());
         assertEquals(5, errors.get());
-
+        assertEquals(5, sends.get());
 
         final CountDownLatch endLatch = new CountDownLatch(2);
         clientPub.end().onSuccess(event -> endLatch.countDown());

--- a/src/test/java/io/nats/vertx/NatsStreamTest.java
+++ b/src/test/java/io/nats/vertx/NatsStreamTest.java
@@ -377,7 +377,7 @@ public class NatsStreamTest {
             error.set(event);
             latch.countDown();
         });
-        latch.await(1, TimeUnit.SECONDS);
+        latch.await(10, TimeUnit.SECONDS);
         if (error.get() != null) {
             fail();
         }
@@ -958,14 +958,14 @@ public class NatsStreamTest {
 
 
             if (i == 4) {
-                Thread.sleep(100);
+                Thread.sleep(1000);
                 natsServerRunner.close();
-                Thread.sleep(100);
+                Thread.sleep(1000);
             }
         }
 
         Thread.sleep(100);
-        receiveLatch.await(1, TimeUnit.SECONDS);
+        receiveLatch.await(10, TimeUnit.SECONDS);
         errorsLatch.await(10, TimeUnit.SECONDS);
 
         assertEquals(5, queue.size());


### PR DESCRIPTION
# Implementing Pull Subscription

## Implementing Pull Subscription for NATs

Pull subscription is a messaging pattern in which the receiver controls the rate at which messages are received from the publisher. This pattern is useful when the receiver is only sometimes available or when it needs to process messages at its own pace. In NATS, pull subscription can be implemented using the request-reply pattern.

To implement pull subscription in NATS, the receiver first sends a request to the publisher for a message using the request-reply pattern. The request contains a subject that identifies the subscription.

The receiver can then process the message and send another request for the next message. This process can be repeated until the receiver receives all the necessary messages. The receiver can also choose to stop requesting messages at any. To adapt this to Vert.x model, the call to retrieve messages returns a future.

In conclusion, implementing pull subscription in NATS using the request-reply pattern is a valuable messaging pattern when the receiver needs to control the rate at which messages are received from the publisher. It allows the receiver to process messages at its own pace and ensures they are not lost.

## Problems with last beta

The pull subscriber's current implementation (beta 15) does not work well with Vert.x. This is because the worker is literally blocked forever due to the while loop, and the handler is called. If you run this loop for more than a minute, you will see that Vert.x starts to complain that its worker is blocked. Although a blocking worker can run blocking operations, it cannot block indefinitely. Therefore, it is necessary to change this logic. After conversations with the customer architect/lead developer, it was decided to add a method that returns a future which returns message via callback or error if unable to get the next message. 

The interface has changed a lot. Thus, the major version has increased to 2.x.x. The pull method is called `nextMessage` and is used as follows:

### NextMessage 

```java

final Future<Void> subscribe = natsStream.subscribe(SUBJECT_NAME, pullOptions);
...
final Future<Message> messageFuture = natsStream.nextMessage(SUBJECT_NAME);
                messageFuture.onSuccess(event -> {
                    latch.countDown();
                    queue.add(event);
                }).onFailure(event -> event.printStackTrace());
```

If you want to set the pull size before, you can pass a batch size to the `nextMessage` as the second argument. 

### NextMessage with batchSize

```java
final Future<Message> messageFuture = natsStream.nextMessage(SUBJECT_NAME);
                messageFuture.onSuccess(event -> {
                    latch.countDown();
                    queue.add(event);
                }).onFailure(event -> event.printStackTrace());
```

The above will call a subscription pull before retrieving messages. 

You can also call pull to explicitly to get messages ahead of time. 

### Using pull method

```java
Future<Void> pull = natsStream.pull(SUBJECT_NAME, 100);
```

## Another option would be to add a Subsription as a Vet.x stream 

Another improvement could be to create a Subscription object that is also a Vert.x ReadStream. 
Thoughts?


