### PR TITLE
Beta17 Release: Fetch, Iterate and early preview of SubscriptionReadStream. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this component, add the following dependency to the dependencies section 
 ```xml
 <dependency>
   <groupId>io.nats</groupId>
-  <artifactId>nats-vertx-nats-interface</artifactId>
+  <artifactId>nats-vertx-interface</artifactId>
   <version>${maven.version}</version>
 </dependency>
 ```
@@ -24,7 +24,7 @@ To use this component, add the following dependency to the dependencies section 
 #### Gradle (in your `build.gradle` file):
 
 ```
-compile io.nats:nats-vertx-nats-interface:${maven.version}
+compile io.nats:nats-vertx-interface:${maven.version}
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 }
 
-def jarVersion = "2.0.0-beta16"
+def jarVersion = "2.0.0-beta17"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"

--- a/src/main/java/io/nats/vertx/NatsOptions.java
+++ b/src/main/java/io/nats/vertx/NatsOptions.java
@@ -7,6 +7,8 @@ import io.nats.client.impl.ErrorListenerLoggerImpl;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
+import java.time.Duration;
+
 /** Holds the NATS options. */
 public class NatsOptions {
     private Options.Builder natsBuilder;
@@ -32,7 +34,7 @@ public class NatsOptions {
      */
     public Options.Builder getNatsBuilder() {
         if (natsBuilder == null) {
-            natsBuilder = new Options.Builder();
+            natsBuilder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5));
         }
         configureExceptionHandler();
         return natsBuilder;

--- a/src/main/java/io/nats/vertx/NatsStream.java
+++ b/src/main/java/io/nats/vertx/NatsStream.java
@@ -63,6 +63,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param so The PushSubscribeOptions
      * @return future that returns status of subscription.
      */
+    @Deprecated
     Future<Void> subscribe(
             String subject, Handler<NatsVertxMessage> handler, boolean autoAck, PushSubscribeOptions so);
 
@@ -75,6 +76,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param so The PushSubscribeOptions
      * @return future that returns status of subscription.
      */
+    @Deprecated
     Future<Void> subscribe(
             String subject,
             String queue,
@@ -89,7 +91,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param so The PullSubscribeOptions
      * @return future that returns status of subscription.
      */
-    Future<Void> subscribe(
+    Future<SubscriptionReadStream> subscribe(
             String subject, PullSubscribeOptions so) ;
 
 
@@ -98,7 +100,8 @@ public interface NatsStream extends WriteStream<Message> {
      * @param subject The subject of the stream.
      * @return future that returns status of subscription.
      */
-    Future<Void> subscribe(
+    @Deprecated
+    Future<SubscriptionReadStream> subscribe(
             String subject) ;
 
 

--- a/src/main/java/io/nats/vertx/NatsStream.java
+++ b/src/main/java/io/nats/vertx/NatsStream.java
@@ -180,7 +180,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    Future<List<Message>> fetch(final String subject, final int batchSize, final long maxWaitMillis);
+    Future<List<NatsVertxMessage>> fetch(final String subject, final int batchSize, final long maxWaitMillis);
 
     /**
      * Fetch a list of messages up to the batch size, waiting no longer than maxWait.
@@ -192,7 +192,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param maxWait the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    default Future<List<Message>> fetch(final String subject, final int batchSize, final Duration maxWait) {
+    default Future<List<NatsVertxMessage>> fetch(final String subject, final int batchSize, final Duration maxWait) {
         return fetch(subject, batchSize, maxWait.toMillis());
     }
 
@@ -207,7 +207,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    Future<Iterator<Message>> iterate(final String subject, final int batchSize, final long maxWaitMillis);
+    Future<Iterator<NatsVertxMessage>> iterate(final String subject, final int batchSize, final long maxWaitMillis);
 
     /**
      * Prepares an iterator. This uses pullExpiresIn under the covers, and manages all responses.
@@ -220,7 +220,7 @@ public interface NatsStream extends WriteStream<Message> {
      * @param maxWait the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    default Future<Iterator<Message>> iterate(final String subject, final int batchSize, final Duration maxWait) {
+    default Future<Iterator<NatsVertxMessage>> iterate(final String subject, final int batchSize, final Duration maxWait) {
         return iterate(subject, batchSize, maxWait.toMillis());
     }
 

--- a/src/main/java/io/nats/vertx/NatsVertxMessage.java
+++ b/src/main/java/io/nats/vertx/NatsVertxMessage.java
@@ -21,13 +21,8 @@ public interface NatsVertxMessage extends Message{
     /** Wrapper around the Nats Message. */
     Message message();
 
-    /** Reference to the vertx vertical where Futures are scheduled.
-     */
-    Vertx vertx();
 
-    default ContextInternal context() {
-        return (ContextInternal)  vertx().getOrCreateContext();
-    }
+    ContextInternal context();
 
     /**
      * Acknowledge the message as processed successfully.

--- a/src/main/java/io/nats/vertx/SubscriptionReadStream.java
+++ b/src/main/java/io/nats/vertx/SubscriptionReadStream.java
@@ -1,0 +1,69 @@
+package io.nats.vertx;
+
+import io.nats.client.Message;
+import io.vertx.core.Future;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+
+public interface SubscriptionReadStream {
+
+    /**
+     * Retrieve a message from the subscription.
+     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+     * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
+     * @return future message.
+     */
+    Future<List<Message>> fetch(final int batchSize, final long maxWaitMillis);
+
+    /**
+     * Fetch a list of messages up to the batch size, waiting no longer than maxWait.
+     * This uses pullExpiresIn under the covers, and manages all responses from sub.nextMessage(...)
+     * to only return regular JetStream messages. This can only be used when the subscription
+     * is pull based. ! Pull subscriptions only. Push subscription will throw IllegalStateException
+     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+     * @param maxWait the maximum time to wait for the first message, in milliseconds
+     * @return future message.
+     */
+    default Future<List<Message>> fetch( final int batchSize, final Duration maxWait) {
+        return fetch(batchSize, maxWait.toMillis());
+    }
+
+    /**
+     * Prepares an iterator. This uses pullExpiresIn under the covers, and manages all responses.
+     * The iterator will have no messages if it does not receive the first message within
+     * the max wait period. It will stop if the batch is fulfilled or if there are fewer
+     * than batch size messages. 408 Status messages are ignored and will not count toward the
+     * fulfilled batch size. ! Pull subscriptions only. Push subscription will throw IllegalStateException
+     * @param subject subject The subject for the subscription.
+     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+     * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
+     * @return future message.
+     */
+    Future<Iterator<Message>> iterate(final String subject, final int batchSize, final long maxWaitMillis);
+
+    /**
+     * Prepares an iterator. This uses pullExpiresIn under the covers, and manages all responses.
+     * The iterator will have no messages if it does not receive the first message within
+     * the max wait period. It will stop if the batch is fulfilled or if there are fewer
+     * than batch size messages. 408 Status messages are ignored and will not count toward the
+     * fulfilled batch size. ! Pull subscriptions only. Push subscription will throw IllegalStateException
+     * @param subject subject The subject for the subscription.
+     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+     * @param maxWait the maximum time to wait for the first message, in milliseconds
+     * @return future message.
+     */
+    default Future<Iterator<Message>> iterate(final String subject, final int batchSize, final Duration maxWait) {
+        return iterate(subject, batchSize, maxWait.toMillis());
+    }
+
+    /**
+     * Unsubscribe this subscription and stop listening for messages.
+     *
+     * <p>Stops messages to the subscription locally and notifies the server.
+     *
+     * @throws IllegalStateException if the subscription belongs to a dispatcher, or is not active
+     */
+    Future<Void> unsubscribeAsync();
+}

--- a/src/main/java/io/nats/vertx/SubscriptionReadStream.java
+++ b/src/main/java/io/nats/vertx/SubscriptionReadStream.java
@@ -1,6 +1,5 @@
 package io.nats.vertx;
 
-import io.nats.client.Message;
 import io.vertx.core.Future;
 
 import java.time.Duration;
@@ -15,7 +14,7 @@ public interface SubscriptionReadStream {
      * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    Future<List<Message>> fetch(final int batchSize, final long maxWaitMillis);
+    Future<List<NatsVertxMessage>> fetch(final int batchSize, final long maxWaitMillis);
 
     /**
      * Fetch a list of messages up to the batch size, waiting no longer than maxWait.
@@ -26,7 +25,7 @@ public interface SubscriptionReadStream {
      * @param maxWait the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    default Future<List<Message>> fetch( final int batchSize, final Duration maxWait) {
+    default Future<List<NatsVertxMessage>> fetch( final int batchSize, final Duration maxWait) {
         return fetch(batchSize, maxWait.toMillis());
     }
 
@@ -36,12 +35,11 @@ public interface SubscriptionReadStream {
      * the max wait period. It will stop if the batch is fulfilled or if there are fewer
      * than batch size messages. 408 Status messages are ignored and will not count toward the
      * fulfilled batch size. ! Pull subscriptions only. Push subscription will throw IllegalStateException
-     * @param subject subject The subject for the subscription.
      * @param batchSize batchSize The batch size, only use if you passed the right publish options.
      * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    Future<Iterator<Message>> iterate(final String subject, final int batchSize, final long maxWaitMillis);
+    Future<Iterator<NatsVertxMessage>> iterate( final int batchSize, final long maxWaitMillis);
 
     /**
      * Prepares an iterator. This uses pullExpiresIn under the covers, and manages all responses.
@@ -49,13 +47,12 @@ public interface SubscriptionReadStream {
      * the max wait period. It will stop if the batch is fulfilled or if there are fewer
      * than batch size messages. 408 Status messages are ignored and will not count toward the
      * fulfilled batch size. ! Pull subscriptions only. Push subscription will throw IllegalStateException
-     * @param subject subject The subject for the subscription.
-     * @param batchSize batchSize The batch size, only use if you passed the right publish options.
+      * @param batchSize batchSize The batch size, only use if you passed the right publish options.
      * @param maxWait the maximum time to wait for the first message, in milliseconds
      * @return future message.
      */
-    default Future<Iterator<Message>> iterate(final String subject, final int batchSize, final Duration maxWait) {
-        return iterate(subject, batchSize, maxWait.toMillis());
+    default Future<Iterator<NatsVertxMessage>> iterate( final int batchSize, final Duration maxWait) {
+        return iterate( batchSize, maxWait.toMillis());
     }
 
     /**

--- a/src/main/java/io/nats/vertx/impl/NatsVertxMessageImpl.java
+++ b/src/main/java/io/nats/vertx/impl/NatsVertxMessageImpl.java
@@ -1,0 +1,35 @@
+package io.nats.vertx.impl;
+
+import io.nats.client.Message;
+import io.nats.vertx.NatsVertxMessage;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NatsVertxMessageImpl implements NatsVertxMessage {
+
+    public static List<NatsVertxMessage> listOf(List<Message> messages, ContextInternal contextInternal) {
+        return messages.stream().map(m -> new NatsVertxMessageImpl( m, contextInternal)).collect(Collectors.toList());
+    }
+
+    private final Message event;
+    private final ContextInternal contextInternal;
+
+    public NatsVertxMessageImpl(Message event, ContextInternal contextInternal) {
+        this.event = event;
+        this.contextInternal = contextInternal;
+    }
+
+
+    @Override
+    public Message message() {
+        return event;
+    }
+
+    @Override
+    public ContextInternal context() {
+        return contextInternal;
+    }
+}

--- a/src/main/java/io/nats/vertx/impl/SubscriptionReadStreamImpl.java
+++ b/src/main/java/io/nats/vertx/impl/SubscriptionReadStreamImpl.java
@@ -1,0 +1,63 @@
+package io.nats.vertx.impl;
+
+import io.nats.client.JetStreamSubscription;
+import io.nats.client.Message;
+import io.nats.vertx.SubscriptionReadStream;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.ContextInternal;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SubscriptionReadStreamImpl implements SubscriptionReadStream {
+    private final ContextInternal context;
+    private final JetStreamSubscription subscription;
+    private final AtomicReference<Handler<Throwable>> exceptionHandler;
+
+    public SubscriptionReadStreamImpl(ContextInternal context, JetStreamSubscription subscription, AtomicReference<Handler<Throwable>> exceptionHandler) {
+        this.context = context;
+        this.subscription = subscription;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public Future<List<Message>> fetch(int batchSize, long maxWaitMillis) {
+        final Promise<List<Message>> promise = context.promise();
+        context.executeBlocking(evt -> {
+            try {
+                final List<Message> messages = subscription.fetch(batchSize, maxWaitMillis);
+                promise.complete(messages);
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
+    public Future<Iterator<Message>> iterate(String subject, int batchSize, long maxWaitMillis) {
+        final Promise<Iterator<Message>> promise = context.promise();
+        context.executeBlocking(evt -> {
+            try {
+                final Iterator<Message> messages = subscription.iterate(batchSize, maxWaitMillis);
+                promise.complete(messages);
+            } catch (Exception e) {
+                handleException(promise, e);
+            }
+        }, false);
+        return promise.future();
+    }
+
+    @Override
+    public Future<Void> unsubscribeAsync() {
+        return null;
+    }
+
+    private void handleException(Promise<?> promise, Exception e) {
+        promise.fail(e);
+        exceptionHandler.get().handle(e);
+    }
+}

--- a/src/test/java/io/nats/vertx/JetStreamClusterMain.java
+++ b/src/test/java/io/nats/vertx/JetStreamClusterMain.java
@@ -137,7 +137,7 @@ public class JetStreamClusterMain {
     }
 
     private static Connection getConnection() throws IOException, InterruptedException {
-        final Options options = new Options.Builder()
+        final Options options = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"nats://localhost:4221", "nats://localhost:4222",
                 "nats://localhost:4223"}).connectionListener(new ConnectionListener() {
             @Override

--- a/src/test/java/io/nats/vertx/LoadTestMain.java
+++ b/src/test/java/io/nats/vertx/LoadTestMain.java
@@ -8,6 +8,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -110,7 +111,7 @@ public class LoadTestMain {
     public static void setup(int port) throws Exception {
 
 
-        Options.Builder builder = new Options.Builder()
+        Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"localhost:" + port});
         Connection nc = Nats.connect(builder.build());
         JetStreamManagement jsm = nc.jetStreamManagement();

--- a/src/test/java/io/nats/vertx/LoadTestOriginalMain.java
+++ b/src/test/java/io/nats/vertx/LoadTestOriginalMain.java
@@ -90,7 +90,7 @@ public class LoadTestOriginalMain {
     public static void setup(int port) throws Exception {
 
 
-        Options.Builder builder = new Options.Builder()
+        Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"localhost:" + port});
         Connection nc = Nats.connect(builder.build());
         JetStreamManagement jsm = nc.jetStreamManagement();
@@ -117,7 +117,7 @@ public class LoadTestOriginalMain {
     }
 
     static Connection getNatsClient(int port) throws Exception {
-        final Options.Builder natsOptions = new Options.Builder();
+        final Options.Builder natsOptions = new Options.Builder().connectionTimeout(Duration.ofSeconds(5));
         final CountDownLatch latch = new CountDownLatch(1);
 
         natsOptions.servers(new String[]{"localhost:" + port}).connectionListener(new ConnectionListener() {

--- a/src/test/java/io/nats/vertx/NatsClientTest.java
+++ b/src/test/java/io/nats/vertx/NatsClientTest.java
@@ -6,6 +6,7 @@ import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
 import io.nats.client.impl.Headers;
 import io.nats.client.impl.NatsMessage;
+import io.nats.client.support.Status;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.*;
@@ -43,14 +45,10 @@ public class NatsClientTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        natsServerRunner = new NatsServerRunner(0, false, true);
-        Thread.sleep(1);
-
-
+        createServer();
         port = natsServerRunner.getPort();
 
-
-        Options.Builder builder = new Options.Builder()
+        Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"localhost:" + port});
         nc = Nats.connect(builder.build());
         JetStreamManagement jsm = nc.jetStreamManagement();
@@ -795,5 +793,85 @@ public class NatsClientTest {
             throw new IllegalStateException(error.get());
         }
         return natsClient;
+    }
+
+
+    private void createServer() throws IOException, InterruptedException {
+        natsServerRunner = new NatsServerRunner(0, false, true);
+        Thread.sleep(200);
+
+
+        port = natsServerRunner.getPort();
+
+
+
+        for (int i = 0; i < 100; i++) {
+            Thread.sleep(200);
+            final AtomicReference<ConnectionListener.Events> lastEvent = new AtomicReference<>();
+            final CountDownLatch latch = new CountDownLatch(1);
+            final String serverName = "name" + System.currentTimeMillis();
+
+            Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
+                    .servers(new String[]{"localhost:" + port}).errorListener(new ErrorListener() {
+                        @Override
+                        public void errorOccurred(Connection conn, String error) {
+                            System.out.println(error);
+                        }
+
+                        @Override
+                        public void exceptionOccurred(Connection conn, Exception exp) {
+                            exp.printStackTrace();
+                        }
+
+                        @Override
+                        public void slowConsumerDetected(Connection conn, Consumer consumer) {
+                            ErrorListener.super.slowConsumerDetected(conn, consumer);
+                        }
+
+                        @Override
+                        public void messageDiscarded(Connection conn, Message msg) {
+                            ErrorListener.super.messageDiscarded(conn, msg);
+                        }
+
+                        @Override
+                        public void heartbeatAlarm(Connection conn, JetStreamSubscription sub, long lastStreamSequence, long lastConsumerSequence) {
+                            ErrorListener.super.heartbeatAlarm(conn, sub, lastStreamSequence, lastConsumerSequence);
+                        }
+
+                        @Override
+                        public void unhandledStatus(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.unhandledStatus(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusWarning(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusError(conn, sub, status);
+                        }
+
+                        @Override
+                        public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String subject, FlowControlSource source) {
+                            ErrorListener.super.flowControlProcessed(conn, sub, subject, source);
+                        }
+                    }).connectionListener(new ConnectionListener() {
+                        @Override
+                        public void connectionEvent(Connection conn, Events type) {
+                            lastEvent.set(type);
+                            latch.countDown();
+                            System.out.println("CONNECTION " + type);
+                        }
+                    }).connectionName(serverName);
+            Connection connect = Nats.connect(builder.build());
+            latch.await(1, TimeUnit.SECONDS);
+            if (lastEvent.get() == ConnectionListener.Events.CONNECTED) {
+                connect.close();
+                break;
+            }
+
+        }
     }
 }

--- a/src/test/java/io/nats/vertx/NatsClientTest.java
+++ b/src/test/java/io/nats/vertx/NatsClientTest.java
@@ -10,10 +10,13 @@ import io.nats.client.support.Status;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
 import nats.io.NatsServerRunner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(VertxExtension.class)
 public class NatsClientTest {
 
     final String SUBJECT_NAME = "testSubject";
@@ -71,7 +75,7 @@ public class NatsClientTest {
     @Test
     public void testConnect() throws InterruptedException {
 
-        final NatsClient natsClient = getNatsClient();
+        final NatsClient natsClient = TestUtils.natsClient(port, Vertx.vertx(), Throwable::printStackTrace);
 
         assertNotNull(natsClient.getConnection());
 
@@ -80,8 +84,10 @@ public class NatsClientTest {
     @Test
     public void testPubSub() throws InterruptedException {
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        Vertx vertx = Vertx.vertx();
+
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(10);
@@ -106,8 +112,8 @@ public class NatsClientTest {
                 .onSuccess(event -> System.out.println("Success"));
 
 
-        closeClient(natsClientPub);
-        closeClient(natsClientSub);
+        TestUtils.closeClient(natsClientPub);
+        TestUtils.closeClient(natsClientSub);
 
 
     }
@@ -116,8 +122,8 @@ public class NatsClientTest {
     @Test
     public void testPubSub100() throws InterruptedException {
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);;
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(100);
@@ -136,8 +142,8 @@ public class NatsClientTest {
         latch.await(10, TimeUnit.SECONDS);
 
         assertTrue(queue.size() > 98);
-        closeClient(natsClientPub);
-        closeClient(natsClientSub);
+        TestUtils.closeClient(natsClientPub);
+        TestUtils.closeClient(natsClientSub);
 
 
     }
@@ -145,8 +151,8 @@ public class NatsClientTest {
     @Test
     public void testWriteSub() throws InterruptedException {
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -182,8 +188,8 @@ public class NatsClientTest {
     public void testWriteAsyncResultSub() throws InterruptedException {
 
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -222,8 +228,8 @@ public class NatsClientTest {
     @Test
     public void testPubMessageSub() throws InterruptedException {
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);;
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -259,8 +265,8 @@ public class NatsClientTest {
     public void testPubMessageAsyncResultSub() throws InterruptedException {
 
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -299,8 +305,8 @@ public class NatsClientTest {
     public void testPubMessageSubWithHeaderAndReplyTo() throws InterruptedException {
 
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -331,8 +337,8 @@ public class NatsClientTest {
 
         assertEquals(10, queue.size());
 
-        closeClient(natsClientPub);
-        closeClient(natsClientSub);
+        TestUtils.closeClient(natsClientPub);
+        TestUtils.closeClient(natsClientSub);
     }
 
 
@@ -340,8 +346,8 @@ public class NatsClientTest {
     public void testPubMessageSubWithHeader() throws InterruptedException {
 
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch receiveLatch = new CountDownLatch(10);
@@ -372,16 +378,16 @@ public class NatsClientTest {
 
         assertEquals(10, queue.size());
 
-        closeClient(natsClientPub);
-        closeClient(natsClientSub);
+        TestUtils.closeClient(natsClientPub);
+        TestUtils.closeClient(natsClientSub);
     }
 
 
     @Test
     public void testPubSubReplyTo() throws InterruptedException {
 
-        final NatsClient natsClientPub = getNatsClient();
-        final NatsClient natsClientSub = getNatsClient();
+        final NatsClient natsClientPub = TestUtils.natsClient(port);
+        final NatsClient natsClientSub = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(10);
@@ -411,8 +417,8 @@ public class NatsClientTest {
     @Test
     public void testRequestReply() throws InterruptedException {
 
-        final NatsClient natsRequester = getNatsClient();
-        final NatsClient natsReply = getNatsClient();
+        final NatsClient natsRequester = TestUtils.natsClient(port);
+        final NatsClient natsReply = TestUtils.natsClient(port);
 
 
         natsReply.subscribe("REQUEST_SUBJECT", event -> {
@@ -444,15 +450,15 @@ public class NatsClientTest {
         assertNotNull(reply);
         assertEquals("HELLO_MOM", new String(reply.getData(), StandardCharsets.UTF_8));
 
-        closeClient(natsRequester);
-        closeClient(natsReply);
+        TestUtils.closeClient(natsRequester);
+        TestUtils.closeClient(natsReply);
     }
 
     @Test
     public void testRequestMessageReply() throws InterruptedException {
 
-        final NatsClient natsRequester = getNatsClient();
-        final NatsClient natsReply = getNatsClient();
+        final NatsClient natsRequester = TestUtils.natsClient(port);
+        final NatsClient natsReply = TestUtils.natsClient(port);
 
 
         natsReply.subscribe("REQUEST_SUBJECT", event -> {
@@ -490,16 +496,16 @@ public class NatsClientTest {
         assertNotNull(reply);
         assertEquals("HELLO_MOM", new String(reply.getData(), StandardCharsets.UTF_8));
 
-        closeClient(natsRequester);
-        closeClient(natsReply);
+        TestUtils.closeClient(natsRequester);
+        TestUtils.closeClient(natsReply);
     }
 
 
     @Test
     public void testRequestMessageReplyWithHeaders() throws InterruptedException {
 
-        final NatsClient natsRequester = getNatsClient();
-        final NatsClient natsReply = getNatsClient();
+        final NatsClient natsRequester = TestUtils.natsClient(port);
+        final NatsClient natsReply = TestUtils.natsClient(port);
         final Headers headers = new Headers().put("key", "value");
 
 
@@ -544,16 +550,16 @@ public class NatsClientTest {
 
 
 
-        closeClient(natsRequester);
-        closeClient(natsReply);
+        TestUtils.closeClient(natsRequester);
+        TestUtils.closeClient(natsReply);
     }
 
 
     @Test
     public void testRequestMessageReplyWithHeadersAndDuration() throws InterruptedException {
 
-        final NatsClient natsRequester = getNatsClient();
-        final NatsClient natsReply = getNatsClient();
+        final NatsClient natsRequester = TestUtils.natsClient(port);
+        final NatsClient natsReply = TestUtils.natsClient(port);
         final Headers headers = new Headers().put("key", "value");
         final Duration duration = Duration.ofSeconds(5);
 
@@ -599,15 +605,15 @@ public class NatsClientTest {
 
 
 
-        closeClient(natsRequester);
-        closeClient(natsReply);
+        TestUtils.closeClient(natsRequester);
+        TestUtils.closeClient(natsReply);
     }
 
     @Test
     public void testRequestMessageReplyAsyncResult() throws InterruptedException {
 
-        final NatsClient natsRequester = getNatsClient();
-        final NatsClient natsReply = getNatsClient();
+        final NatsClient natsRequester = TestUtils.natsClient(port);
+        final NatsClient natsReply = TestUtils.natsClient(port);
 
 
         natsReply.subscribe("REQUEST_SUBJECT", event -> {
@@ -648,14 +654,14 @@ public class NatsClientTest {
         assertNotNull(reply);
         assertEquals("HELLO_MOM", new String(reply.getData(), StandardCharsets.UTF_8));
 
-        closeClient(natsRequester);
-        closeClient(natsReply);
+        TestUtils.closeClient(natsRequester);
+        TestUtils.closeClient(natsReply);
     }
 
     @Test
     public void testSub() throws InterruptedException {
 
-        final NatsClient natsClient = getNatsClient();
+        final NatsClient natsClient = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(10);
@@ -680,13 +686,13 @@ public class NatsClientTest {
 
         assertTrue( queue.size() >= 8);
 
-        closeClient(natsClient);
+        TestUtils.closeClient(natsClient);
     }
 
     @Test
     public void testSubWithError() throws InterruptedException {
 
-        final NatsClient natsClient = getNatsClient();
+        final NatsClient natsClient = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(10);
@@ -705,14 +711,14 @@ public class NatsClientTest {
 
         latch.await(1, TimeUnit.SECONDS);
 
-        closeClient(natsClient);
+        TestUtils.closeClient(natsClient);
     }
 
 
     @Test
     public void testSubWithQueueName() throws InterruptedException {
 
-        final NatsClient natsClient = getNatsClient();
+        final NatsClient natsClient = TestUtils.natsClient(port);
 
 
         final CountDownLatch latch = new CountDownLatch(10);
@@ -738,140 +744,25 @@ public class NatsClientTest {
         natsClient.unsubscribe(SUBJECT_NAME);
 
         assertTrue(queue.size() > 8);
-        closeClient(natsClient);
+        TestUtils.closeClient(natsClient);
     }
 
     @Test
     public void testForceFail() throws InterruptedException {
 
         try {
-            final NatsClient natsClient = getNatsClient(port + 10);
+            final NatsClient natsClient = TestUtils.natsClient(port + 10);
             fail();
         } catch (Exception ex) {
 
         }
     }
 
-    private void closeClient(NatsClient natsClient) throws InterruptedException {
-        final CountDownLatch endLatch = new CountDownLatch(1);
-        natsClient.end().onSuccess(event -> endLatch.countDown()).onFailure(error -> error.printStackTrace());
-        endLatch.await(10, TimeUnit.SECONDS);
-        if ( endLatch.getCount() > 0 ) {
-            fail();
-        }
 
 
-    }
 
-    private NatsClient getNatsClient() throws InterruptedException {
-       return getNatsClient(port);
-    }
-    private NatsClient getNatsClient(int port) throws InterruptedException {
-        final NatsOptions natsOptions = new NatsOptions();
-        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port});
-        final NatsClient natsClient = NatsClient.create(natsOptions);
-        final Future<Void> connect = natsClient.connect();
-
-        natsClient.exceptionHandler(Throwable::printStackTrace);
-
-        //No op methods
-        natsClient.setWriteQueueMaxSize(100);
-        natsClient.writeQueueFull();
-        natsClient.drainHandler(event -> {
-        });
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> error = new AtomicReference<>();
-        connect.onSuccess(event -> {
-            latch.countDown();
-        }).onFailure(event -> {
-            error.set(event);
-            latch.countDown();
-        }).onFailure(Throwable::printStackTrace);
-        latch.await(1, TimeUnit.SECONDS);
-        if (error.get() != null) {
-            throw new IllegalStateException(error.get());
-        }
-        return natsClient;
-    }
-
-
-    private void createServer() throws IOException, InterruptedException {
-        natsServerRunner = new NatsServerRunner(0, false, true);
-        Thread.sleep(200);
-
-
+    private void createServer() throws Exception {
+        natsServerRunner = TestUtils.startServer();
         port = natsServerRunner.getPort();
-
-
-
-        for (int i = 0; i < 100; i++) {
-            Thread.sleep(200);
-            final AtomicReference<ConnectionListener.Events> lastEvent = new AtomicReference<>();
-            final CountDownLatch latch = new CountDownLatch(1);
-            final String serverName = "name" + System.currentTimeMillis();
-
-            Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
-                    .servers(new String[]{"localhost:" + port}).errorListener(new ErrorListener() {
-                        @Override
-                        public void errorOccurred(Connection conn, String error) {
-                            System.out.println(error);
-                        }
-
-                        @Override
-                        public void exceptionOccurred(Connection conn, Exception exp) {
-                            exp.printStackTrace();
-                        }
-
-                        @Override
-                        public void slowConsumerDetected(Connection conn, Consumer consumer) {
-                            ErrorListener.super.slowConsumerDetected(conn, consumer);
-                        }
-
-                        @Override
-                        public void messageDiscarded(Connection conn, Message msg) {
-                            ErrorListener.super.messageDiscarded(conn, msg);
-                        }
-
-                        @Override
-                        public void heartbeatAlarm(Connection conn, JetStreamSubscription sub, long lastStreamSequence, long lastConsumerSequence) {
-                            ErrorListener.super.heartbeatAlarm(conn, sub, lastStreamSequence, lastConsumerSequence);
-                        }
-
-                        @Override
-                        public void unhandledStatus(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.unhandledStatus(conn, sub, status);
-                        }
-
-                        @Override
-                        public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.pullStatusWarning(conn, sub, status);
-                        }
-
-                        @Override
-                        public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.pullStatusError(conn, sub, status);
-                        }
-
-                        @Override
-                        public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String subject, FlowControlSource source) {
-                            ErrorListener.super.flowControlProcessed(conn, sub, subject, source);
-                        }
-                    }).connectionListener(new ConnectionListener() {
-                        @Override
-                        public void connectionEvent(Connection conn, Events type) {
-                            lastEvent.set(type);
-                            latch.countDown();
-                            System.out.println("CONNECTION " + type);
-                        }
-                    }).connectionName(serverName);
-            Connection connect = Nats.connect(builder.build());
-            latch.await(1, TimeUnit.SECONDS);
-            if (lastEvent.get() == ConnectionListener.Events.CONNECTED) {
-                connect.close();
-                break;
-            }
-
-        }
     }
 }

--- a/src/test/java/io/nats/vertx/NatsSimplePerfTest.java
+++ b/src/test/java/io/nats/vertx/NatsSimplePerfTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,7 +47,7 @@ public class NatsSimplePerfTest {
         port = natsServerRunner.getPort();
 
 
-        Options.Builder builder = new Options.Builder()
+        Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"localhost:" + port});
         nc = Nats.connect(builder.build());
         JetStreamManagement jsm = nc.jetStreamManagement();

--- a/src/test/java/io/nats/vertx/NatsStreamTest.java
+++ b/src/test/java/io/nats/vertx/NatsStreamTest.java
@@ -195,7 +195,7 @@ public class NatsStreamTest {
         final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(20);
         final String data = "data";
         final CountDownLatch startLatch = new CountDownLatch(1);
-        final Future<Void> subscribe = natsStream.subscribe(SUBJECT_NAME, PullSubscribeOptions.builder().build());
+        final Future<SubscriptionReadStream> subscribe = natsStream.subscribe(SUBJECT_NAME, PullSubscribeOptions.builder().build());
         subscribe.onSuccess(event -> startLatch.countDown()).onFailure(event -> event.printStackTrace());
         startLatch.await(10, TimeUnit.SECONDS);
         System.out.println("Started subscription");
@@ -234,7 +234,7 @@ public class NatsStreamTest {
         final BlockingQueue<Message> queue = new ArrayBlockingQueue<>(20);
         final String data = "data";
         final CountDownLatch startLatch = new CountDownLatch(1);
-        final Future<Void> subscribe = natsStream.subscribe(SUBJECT_NAME, PullSubscribeOptions.builder().build());
+        final Future<SubscriptionReadStream> subscribe = natsStream.subscribe(SUBJECT_NAME, PullSubscribeOptions.builder().build());
         subscribe.onSuccess(event -> startLatch.countDown()).onFailure(event -> event.printStackTrace());
         startLatch.await(10, TimeUnit.SECONDS);
         System.out.println("Started subscription");

--- a/src/test/java/io/nats/vertx/NatsStreamTest.java
+++ b/src/test/java/io/nats/vertx/NatsStreamTest.java
@@ -773,28 +773,21 @@ public class NatsStreamTest {
 
         for (int i = 0; i < 10; i++) {
 
-
-            final NatsMessage message = NatsMessage.builder().subject(SUBJECT_NAME)
-                    .data(data + i, StandardCharsets.UTF_8)
-                    .build();
-
             jetStreamPub.publish(SUBJECT_NAME, data + i)
-                    .onSuccess(event -> {
-
-                                sends.incrementAndGet();
-                                System.out.println("SUCCESS " + sends.get());
-                            }
+                    .onSuccess(event -> sends.incrementAndGet()
                     ).onFailure(error -> {
-                        System.out.println("ERROR " + errors.get());
                         errors.incrementAndGet();
                         errorsLatch.countDown();
                     });
 
-
             if (i == 4) {
-                Thread.sleep(1000);
-                natsServerRunner.close();
-                Thread.sleep(1000);
+                try {
+                    Thread.sleep(1000);
+                    natsServerRunner.close();
+                    Thread.sleep(1000);
+                }catch (Exception ex) {
+                    ex.printStackTrace();
+                }
             }
         }
 
@@ -852,21 +845,22 @@ public class NatsStreamTest {
 
             jetStreamPub.publish(message, po)
                     .onSuccess(event -> {
-
                                 sends.incrementAndGet();
-                                System.out.println("SUCCESS " + sends.get());
                             }
                     ).onFailure(error -> {
-                        System.out.println("ERROR " + errors.get());
                         errors.incrementAndGet();
                         errorsLatch.countDown();
                     });
 
 
             if (i == 4) {
-                Thread.sleep(100);
-                natsServerRunner.close();
-                Thread.sleep(100);
+                try {
+                    Thread.sleep(100);
+                    natsServerRunner.close();
+                    Thread.sleep(100);
+                }catch (Exception ex) {
+                    ex.printStackTrace();
+                }
             }
         }
 

--- a/src/test/java/io/nats/vertx/TestUtils.java
+++ b/src/test/java/io/nats/vertx/TestUtils.java
@@ -1,0 +1,176 @@
+package io.nats.vertx;
+
+import io.nats.client.*;
+import io.nats.client.support.Status;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import nats.io.NatsServerRunner;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestUtils {
+
+    public static NatsStream jetStream(NatsClient natsClient) {
+        final JetStreamOptions options = JetStreamOptions.builder().build();
+        final Future<NatsStream> connect = natsClient.jetStream(options);
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicReference<NatsStream> stream = new AtomicReference<>();
+        connect.onSuccess(event -> {
+            stream.set(event);
+            latch.countDown();
+        }).onFailure(event -> {
+            error.set(event);
+            latch.countDown();
+        });
+        try {
+            latch.await(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (error.get() != null) {
+            fail();
+        }
+        return stream.get();
+    }
+
+
+     public static void closeClient(NatsClient natsClient) {
+        final CountDownLatch endLatch = new CountDownLatch(1);
+        natsClient.end().onSuccess(event -> endLatch.countDown());
+        try {
+            endLatch.await(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static NatsClient natsClient(int port) {
+        return natsClient(port, Vertx.vertx(), Throwable::printStackTrace);
+    }
+
+    public static NatsClient natsClient(int port, Vertx vertx, Handler<Throwable> exceptionHandler) {
+        final NatsOptions natsOptions = new NatsOptions();
+        natsOptions.setVertx(vertx);
+        natsOptions.setExceptionHandler(exceptionHandler);
+        natsOptions.setNatsBuilder(new Options.Builder().connectionTimeout(Duration.ofSeconds(5)));
+        System.out.println("Client connecting to localhost:" + port);
+        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port})
+                .connectionListener((conn, type) -> {
+                    System.out.println("Connection EVENT " + type);
+
+                });
+        final NatsClient natsClient = NatsClient.create(natsOptions);
+        final Future<Void> connect = natsClient.connect();
+
+        //No op methods
+        natsClient.setWriteQueueMaxSize(100);
+        natsClient.writeQueueFull();
+        natsClient.drainHandler(event -> {
+        });
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        connect.onSuccess(event -> {
+            latch.countDown();
+        }).onFailure(event -> {
+            error.set(event);
+            latch.countDown();
+        });
+        try {
+            latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (error.get() != null) {
+            throw new IllegalStateException(error.get());
+        }
+        return natsClient;
+    }
+
+
+
+    public static NatsServerRunner startServer() throws Exception {
+        NatsServerRunner natsServerRunner = new NatsServerRunner(0, false, true);
+
+        int port = natsServerRunner.getPort();
+        for (int i = 0; i < 100; i++) {
+            Thread.sleep(200);
+            final AtomicReference<ConnectionListener.Events> lastEvent = new AtomicReference<>();
+            final CountDownLatch latch = new CountDownLatch(1);
+            final String serverName = "name" + System.currentTimeMillis();
+
+            Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
+                    .servers(new String[]{"localhost:" + port}).errorListener(new ErrorListener() {
+                        @Override
+                        public void errorOccurred(Connection conn, String error) {
+                            System.out.println(error);
+                        }
+
+                        @Override
+                        public void exceptionOccurred(Connection conn, Exception exp) {
+                            exp.printStackTrace();
+                        }
+
+                        @Override
+                        public void slowConsumerDetected(Connection conn, Consumer consumer) {
+                            ErrorListener.super.slowConsumerDetected(conn, consumer);
+                        }
+
+                        @Override
+                        public void messageDiscarded(Connection conn, Message msg) {
+                            ErrorListener.super.messageDiscarded(conn, msg);
+                        }
+
+                        @Override
+                        public void heartbeatAlarm(Connection conn, JetStreamSubscription sub, long lastStreamSequence, long lastConsumerSequence) {
+                            ErrorListener.super.heartbeatAlarm(conn, sub, lastStreamSequence, lastConsumerSequence);
+                        }
+
+                        @Override
+                        public void unhandledStatus(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.unhandledStatus(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusWarning(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusError(conn, sub, status);
+                        }
+
+                        @Override
+                        public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String subject, FlowControlSource source) {
+                            ErrorListener.super.flowControlProcessed(conn, sub, subject, source);
+                        }
+                    }).connectionListener(new ConnectionListener() {
+                        @Override
+                        public void connectionEvent(Connection conn, Events type) {
+                            lastEvent.set(type);
+                            latch.countDown();
+                            System.out.println("CONNECTION " + type);
+                        }
+                    }).connectionName(serverName);
+            Connection connect = Nats.connect(builder.build());
+            latch.await(200, TimeUnit.MILLISECONDS);
+            if (lastEvent.get() == ConnectionListener.Events.CONNECTED) {
+                connect.close();
+                break;
+            }
+
+        }
+
+        return natsServerRunner;
+    }
+
+}

--- a/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
+++ b/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
@@ -5,10 +5,8 @@ import io.nats.client.*;
 import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import io.nats.client.support.Status;
 import io.nats.vertx.*;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -16,22 +14,10 @@ import nats.io.NatsServerRunner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(VertxExtension.class)
 class SubscriptionReadStreamImplTest {
@@ -45,11 +31,9 @@ class SubscriptionReadStreamImplTest {
     static int port;
 
     @Test
-    public void testFetch(final VertxTestContext testContext) throws Exception {
-        final NatsClient natsClient = natsClient(Vertx.vertx(), testContext, error -> {
-          error.printStackTrace();
-        });
-        final NatsStream natsStream = jetStream(natsClient);
+    public void testFetch(final VertxTestContext testContext) {
+        final NatsClient natsClient = TestUtils.natsClient(port, Vertx.vertx(), Throwable::printStackTrace);
+        final NatsStream natsStream = TestUtils.jetStream(natsClient);
         final String data = "data";
         final Future<SubscriptionReadStream> subscribeFuture = natsStream.subscribe(subjectName,
                 PullSubscribeOptions.builder().build());
@@ -68,7 +52,7 @@ class SubscriptionReadStreamImplTest {
                             messageCount.addAndGet(events.size());
                             if (messageCount.get() > 9) {
                                 testContext.completeNow();
-                                closeClient(natsClient);
+                                TestUtils.closeClient(natsClient);
                             }
                         }).onFailure(testContext::failNow);
                     }
@@ -84,11 +68,9 @@ class SubscriptionReadStreamImplTest {
 
 
     @Test
-    public void testIterate(final VertxTestContext testContext) throws Exception {
-        final NatsClient natsClient = natsClient(Vertx.vertx(), testContext, error -> {
-            error.printStackTrace();
-        });
-        final NatsStream natsStream = jetStream(natsClient);
+    public void testIterate(final VertxTestContext testContext) {
+        final NatsClient natsClient = TestUtils.natsClient(port, Vertx.vertx(), Throwable::printStackTrace);
+        final NatsStream natsStream = TestUtils.jetStream(natsClient);
         final String data = "data";
         final Future<SubscriptionReadStream> subscribeFuture = natsStream.subscribe(subjectName,
                 PullSubscribeOptions.builder().build());
@@ -111,7 +93,7 @@ class SubscriptionReadStreamImplTest {
                             }
                             if (messageCount.get() > 9) {
                                 testContext.completeNow();
-                                closeClient(natsClient);
+                                TestUtils.closeClient(natsClient);
                             }
                         }).onFailure(testContext::failNow);
                     }
@@ -158,162 +140,19 @@ class SubscriptionReadStreamImplTest {
         if (streamInfo == null) {
             StreamConfiguration sc = StreamConfiguration.builder().name(subjectName).storageType(StorageType.Memory).build();
             // Add or use an existing stream.
-            StreamInfo streamInfo1 = jsm.addStream(sc);
+           jsm.addStream(sc);
         }
 
     }
     @BeforeAll
     public static void setupAll() throws Exception {
-        natsServerRunner = new NatsServerRunner(0, false, true);
+        natsServerRunner = TestUtils.startServer();
         port = natsServerRunner.getPort();
-
-
-
-        for (int i = 0; i < 100; i++) {
-            Thread.sleep(200);
-            final AtomicReference<ConnectionListener.Events> lastEvent = new AtomicReference<>();
-            final CountDownLatch latch = new CountDownLatch(1);
-            final String serverName = "name" + System.currentTimeMillis();
-
-            Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
-                    .servers(new String[]{"localhost:" + port}).errorListener(new ErrorListener() {
-                        @Override
-                        public void errorOccurred(Connection conn, String error) {
-                            System.out.println(error);
-                        }
-
-                        @Override
-                        public void exceptionOccurred(Connection conn, Exception exp) {
-                            exp.printStackTrace();
-                        }
-
-                        @Override
-                        public void slowConsumerDetected(Connection conn, Consumer consumer) {
-                            ErrorListener.super.slowConsumerDetected(conn, consumer);
-                        }
-
-                        @Override
-                        public void messageDiscarded(Connection conn, Message msg) {
-                            ErrorListener.super.messageDiscarded(conn, msg);
-                        }
-
-                        @Override
-                        public void heartbeatAlarm(Connection conn, JetStreamSubscription sub, long lastStreamSequence, long lastConsumerSequence) {
-                            ErrorListener.super.heartbeatAlarm(conn, sub, lastStreamSequence, lastConsumerSequence);
-                        }
-
-                        @Override
-                        public void unhandledStatus(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.unhandledStatus(conn, sub, status);
-                        }
-
-                        @Override
-                        public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.pullStatusWarning(conn, sub, status);
-                        }
-
-                        @Override
-                        public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
-                            ErrorListener.super.pullStatusError(conn, sub, status);
-                        }
-
-                        @Override
-                        public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String subject, FlowControlSource source) {
-                            ErrorListener.super.flowControlProcessed(conn, sub, subject, source);
-                        }
-                    }).connectionListener(new ConnectionListener() {
-                        @Override
-                        public void connectionEvent(Connection conn, Events type) {
-                            lastEvent.set(type);
-                            latch.countDown();
-                            System.out.println("CONNECTION " + type);
-                        }
-                    }).connectionName(serverName);
-            Connection connect = Nats.connect(builder.build());
-            latch.await(1, TimeUnit.SECONDS);
-            if (lastEvent.get() == ConnectionListener.Events.CONNECTED) {
-                connect.close();
-                break;
-            }
-
-        }
     }
 
 
-    private NatsClient natsClient(Vertx vertx, VertxTestContext testContext, Handler<Throwable> exceptionHandler) {
-        final NatsOptions natsOptions = new NatsOptions();
-        natsOptions.setVertx(vertx);
-        natsOptions.setExceptionHandler(exceptionHandler);
-        natsOptions.setNatsBuilder(new Options.Builder().connectionTimeout(Duration.ofSeconds(5)));
-        System.out.println("Client connecting to localhost:" + port);
-        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port})
-                .connectionListener((conn, type) -> {
-                    System.out.println("Connection EVENT " + type);
 
-                });
-        final NatsClient natsClient = NatsClient.create(natsOptions);
-        final Future<Void> connect = natsClient.connect();
 
-        natsClient.exceptionHandler(Throwable::printStackTrace);
-
-        //No op methods
-        natsClient.setWriteQueueMaxSize(100);
-        natsClient.writeQueueFull();
-        natsClient.drainHandler(event -> {
-        });
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> error = new AtomicReference<>();
-        connect.onSuccess(event -> {
-            latch.countDown();
-        }).onFailure(event -> {
-            error.set(event);
-            latch.countDown();
-        });
-        try {
-            latch.await(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        if (error.get() != null) {
-            throw new IllegalStateException(error.get());
-        }
-        return natsClient;
-    }
-
-    private NatsStream jetStream(NatsClient natsClient) {
-        final JetStreamOptions options = JetStreamOptions.builder().build();
-        final Future<NatsStream> connect = natsClient.jetStream(options);
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> error = new AtomicReference<>();
-        final AtomicReference<NatsStream> stream = new AtomicReference<>();
-        connect.onSuccess(event -> {
-            stream.set(event);
-            latch.countDown();
-        }).onFailure(event -> {
-            error.set(event);
-            latch.countDown();
-        });
-        try {
-            latch.await(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        if (error.get() != null) {
-            fail();
-        }
-        return stream.get();
-    }
-
-    private void closeClient(NatsClient natsClient) {
-        final CountDownLatch endLatch = new CountDownLatch(1);
-        natsClient.end().onSuccess(event -> endLatch.countDown());
-        try {
-            endLatch.await(3, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
 
 }

--- a/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
+++ b/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
@@ -1,0 +1,136 @@
+package io.nats.vertx.impl;
+
+
+import io.nats.client.*;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+import io.nats.client.api.StreamInfo;
+import io.nats.vertx.NatsClient;
+import io.nats.vertx.NatsOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import nats.io.NatsServerRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@ExtendWith(VertxExtension.class)
+class SubscriptionReadStreamImplTest {
+
+    @Test
+    public void testFetch(Vertx vertx, VertxTestContext testContext) throws Exception {
+
+
+    }
+
+
+    @Test
+    void fetch() {
+    }
+
+    @Test
+    void iterate() {
+    }
+
+    @Test
+    void unsubscribeAsync() {
+    }
+
+    final String SUBJECT_NAME = "jetTestSubject";
+
+    NatsServerRunner natsServerRunner;
+
+    Connection nc;
+
+    @AfterEach
+    public void after() throws Exception {
+        if (nc != null)
+            nc.close();
+
+        if (natsServerRunner != null)
+            natsServerRunner.close();
+    }
+
+    int port;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        natsServerRunner = new NatsServerRunner(0, false, true);
+        Thread.sleep(200);
+
+
+        port = natsServerRunner.getPort();
+
+
+        Options.Builder builder = new Options.Builder()
+                .servers(new String[]{"localhost:" + port});
+        nc = Nats.connect(builder.build());
+        JetStreamManagement jsm = nc.jetStreamManagement();
+        StreamInfo streamInfo = null;
+
+        try {
+            streamInfo = jsm.getStreamInfo(SUBJECT_NAME);
+        } catch (Exception ex) {
+            //ex.printStackTrace();
+        }
+
+        if (streamInfo == null) {
+            StreamConfiguration sc = StreamConfiguration.builder().name(SUBJECT_NAME).storageType(StorageType.Memory).build();
+            // Add or use an existing stream.
+            StreamInfo streamInfo1 = jsm.addStream(sc);
+        }
+
+    }
+
+
+
+
+    private NatsClient getNatsClient(Vertx vertx, Handler<Throwable> exceptionHandler) throws InterruptedException {
+        final NatsOptions natsOptions = new NatsOptions();
+        natsOptions.setVertx(Vertx.vertx());
+        natsOptions.setExceptionHandler(exceptionHandler);
+        natsOptions.setNatsBuilder(new Options.Builder());
+        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port}).connectionListener(new ConnectionListener() {
+            @Override
+            public void connectionEvent(Connection conn, Events type) {
+                System.out.println("Connection EVENT " + type);
+            }
+        });
+        final NatsClient natsClient = NatsClient.create(natsOptions);
+        final Future<Void> connect = natsClient.connect();
+
+        natsClient.exceptionHandler(Throwable::printStackTrace);
+
+        //No op methods
+        natsClient.setWriteQueueMaxSize(100);
+        natsClient.writeQueueFull();
+        natsClient.drainHandler(event -> {
+        });
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        connect.onSuccess(event -> {
+            latch.countDown();
+        }).onFailure(event -> {
+            error.set(event);
+            latch.countDown();
+        });
+        latch.await(10, TimeUnit.SECONDS);
+        if (error.get() != null) {
+            throw new IllegalStateException(error.get());
+        }
+        return natsClient;
+    }
+    private NatsClient getNatsClient(Vertx vertx) throws InterruptedException {
+        return getNatsClient(vertx, event -> event.printStackTrace());
+    }
+}

--- a/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
+++ b/src/test/java/io/nats/vertx/impl/SubscriptionReadStreamImplTest.java
@@ -5,106 +5,252 @@ import io.nats.client.*;
 import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import io.nats.vertx.NatsClient;
-import io.nats.vertx.NatsOptions;
+import io.nats.client.support.Status;
+import io.nats.vertx.*;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import nats.io.NatsServerRunner;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(VertxExtension.class)
 class SubscriptionReadStreamImplTest {
 
-    @Test
-    public void testFetch(Vertx vertx, VertxTestContext testContext) throws Exception {
 
-
-    }
-
-
-    @Test
-    void fetch() {
-    }
-
-    @Test
-    void iterate() {
-    }
-
-    @Test
-    void unsubscribeAsync() {
-    }
-
-    final String SUBJECT_NAME = "jetTestSubject";
-
-    NatsServerRunner natsServerRunner;
-
+    final String SUBJECT_NAME = "subscriptionTest";
+    String subjectName;
+    int subjectIndex = 0;
+    static NatsServerRunner natsServerRunner;
     Connection nc;
+    static int port;
 
-    @AfterEach
-    public void after() throws Exception {
-        if (nc != null)
-            nc.close();
+    @Test
+    public void testFetch(final VertxTestContext testContext) throws Exception {
+        final NatsClient natsClient = natsClient(Vertx.vertx(), testContext, error -> {
+          error.printStackTrace();
+        });
+        final NatsStream natsStream = jetStream(natsClient);
+        final String data = "data";
+        final Future<SubscriptionReadStream> subscribeFuture = natsStream.subscribe(subjectName,
+                PullSubscribeOptions.builder().build());
+        subscribeFuture.onSuccess(subscription -> {
+
+                    //Now that you are subscribed, send ten messages.
+                    for (int i = 0; i < 10; i++) {
+                        nc.publish(subjectName, (data + i).getBytes());
+                    }
+
+                    final AtomicInteger messageCount = new AtomicInteger();
+                    for (int i = 0; i < 10; i++) {
+                        final Future<List<NatsVertxMessage>> messageFuture = subscription.fetch(10, Duration.ofSeconds(5));
+                        messageFuture.onSuccess(events -> {
+                            events.forEach(NatsVertxMessage::ack);
+                            messageCount.addAndGet(events.size());
+                            if (messageCount.get() > 9) {
+                                testContext.completeNow();
+                                closeClient(natsClient);
+                            }
+                        }).onFailure(testContext::failNow);
+                    }
+                }
+        ).onFailure(event ->
+                {
+                    event.printStackTrace();
+                    testContext.failNow(event);
+                }
+        );
+    }
+
+
+
+    @Test
+    public void testIterate(final VertxTestContext testContext) throws Exception {
+        final NatsClient natsClient = natsClient(Vertx.vertx(), testContext, error -> {
+            error.printStackTrace();
+        });
+        final NatsStream natsStream = jetStream(natsClient);
+        final String data = "data";
+        final Future<SubscriptionReadStream> subscribeFuture = natsStream.subscribe(subjectName,
+                PullSubscribeOptions.builder().build());
+        subscribeFuture.onSuccess(subscription -> {
+
+                    //Now that you are subscribed, send ten messages.
+                    for (int i = 0; i < 10; i++) {
+                        nc.publish(subjectName, (data + i).getBytes());
+                    }
+
+                    final AtomicInteger messageCount = new AtomicInteger();
+                    for (int i = 0; i < 10; i++) {
+                        final Future<Iterator<NatsVertxMessage>> messageFuture = subscription.iterate(10, Duration.ofSeconds(5));
+                        messageFuture.onSuccess(events -> {
+
+                            while (events.hasNext()) {
+                                NatsVertxMessage e = events.next();
+                                messageCount.addAndGet(1);
+                                e.ack();
+                            }
+                            if (messageCount.get() > 9) {
+                                testContext.completeNow();
+                                closeClient(natsClient);
+                            }
+                        }).onFailure(testContext::failNow);
+                    }
+                }
+        ).onFailure(event ->
+                {
+                    event.printStackTrace();
+                    testContext.failNow(event);
+                }
+        );
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+
 
         if (natsServerRunner != null)
             natsServerRunner.close();
     }
 
-    int port;
+    @AfterEach
+    public void afterEach() throws Exception {
+        if (nc != null)
+            nc.close();
+    }
 
     @BeforeEach
-    public void setup() throws Exception {
-        natsServerRunner = new NatsServerRunner(0, false, true);
-        Thread.sleep(200);
+    public void setupEach() throws Exception {
+        subjectName = SUBJECT_NAME + subjectIndex;
+        subjectIndex++;
 
-
-        port = natsServerRunner.getPort();
-
-
-        Options.Builder builder = new Options.Builder()
+        Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
                 .servers(new String[]{"localhost:" + port});
         nc = Nats.connect(builder.build());
         JetStreamManagement jsm = nc.jetStreamManagement();
         StreamInfo streamInfo = null;
 
         try {
-            streamInfo = jsm.getStreamInfo(SUBJECT_NAME);
+            streamInfo = jsm.getStreamInfo(subjectName);
         } catch (Exception ex) {
             //ex.printStackTrace();
         }
 
         if (streamInfo == null) {
-            StreamConfiguration sc = StreamConfiguration.builder().name(SUBJECT_NAME).storageType(StorageType.Memory).build();
+            StreamConfiguration sc = StreamConfiguration.builder().name(subjectName).storageType(StorageType.Memory).build();
             // Add or use an existing stream.
             StreamInfo streamInfo1 = jsm.addStream(sc);
         }
 
     }
+    @BeforeAll
+    public static void setupAll() throws Exception {
+        natsServerRunner = new NatsServerRunner(0, false, true);
+        port = natsServerRunner.getPort();
 
 
 
+        for (int i = 0; i < 100; i++) {
+            Thread.sleep(200);
+            final AtomicReference<ConnectionListener.Events> lastEvent = new AtomicReference<>();
+            final CountDownLatch latch = new CountDownLatch(1);
+            final String serverName = "name" + System.currentTimeMillis();
 
-    private NatsClient getNatsClient(Vertx vertx, Handler<Throwable> exceptionHandler) throws InterruptedException {
-        final NatsOptions natsOptions = new NatsOptions();
-        natsOptions.setVertx(Vertx.vertx());
-        natsOptions.setExceptionHandler(exceptionHandler);
-        natsOptions.setNatsBuilder(new Options.Builder());
-        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port}).connectionListener(new ConnectionListener() {
-            @Override
-            public void connectionEvent(Connection conn, Events type) {
-                System.out.println("Connection EVENT " + type);
+            Options.Builder builder = new Options.Builder().connectionTimeout(Duration.ofSeconds(5))
+                    .servers(new String[]{"localhost:" + port}).errorListener(new ErrorListener() {
+                        @Override
+                        public void errorOccurred(Connection conn, String error) {
+                            System.out.println(error);
+                        }
+
+                        @Override
+                        public void exceptionOccurred(Connection conn, Exception exp) {
+                            exp.printStackTrace();
+                        }
+
+                        @Override
+                        public void slowConsumerDetected(Connection conn, Consumer consumer) {
+                            ErrorListener.super.slowConsumerDetected(conn, consumer);
+                        }
+
+                        @Override
+                        public void messageDiscarded(Connection conn, Message msg) {
+                            ErrorListener.super.messageDiscarded(conn, msg);
+                        }
+
+                        @Override
+                        public void heartbeatAlarm(Connection conn, JetStreamSubscription sub, long lastStreamSequence, long lastConsumerSequence) {
+                            ErrorListener.super.heartbeatAlarm(conn, sub, lastStreamSequence, lastConsumerSequence);
+                        }
+
+                        @Override
+                        public void unhandledStatus(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.unhandledStatus(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusWarning(conn, sub, status);
+                        }
+
+                        @Override
+                        public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
+                            ErrorListener.super.pullStatusError(conn, sub, status);
+                        }
+
+                        @Override
+                        public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String subject, FlowControlSource source) {
+                            ErrorListener.super.flowControlProcessed(conn, sub, subject, source);
+                        }
+                    }).connectionListener(new ConnectionListener() {
+                        @Override
+                        public void connectionEvent(Connection conn, Events type) {
+                            lastEvent.set(type);
+                            latch.countDown();
+                            System.out.println("CONNECTION " + type);
+                        }
+                    }).connectionName(serverName);
+            Connection connect = Nats.connect(builder.build());
+            latch.await(1, TimeUnit.SECONDS);
+            if (lastEvent.get() == ConnectionListener.Events.CONNECTED) {
+                connect.close();
+                break;
             }
-        });
+
+        }
+    }
+
+
+    private NatsClient natsClient(Vertx vertx, VertxTestContext testContext, Handler<Throwable> exceptionHandler) {
+        final NatsOptions natsOptions = new NatsOptions();
+        natsOptions.setVertx(vertx);
+        natsOptions.setExceptionHandler(exceptionHandler);
+        natsOptions.setNatsBuilder(new Options.Builder().connectionTimeout(Duration.ofSeconds(5)));
+        System.out.println("Client connecting to localhost:" + port);
+        natsOptions.getNatsBuilder().servers(new String[]{"localhost:" + port})
+                .connectionListener((conn, type) -> {
+                    System.out.println("Connection EVENT " + type);
+
+                });
         final NatsClient natsClient = NatsClient.create(natsOptions);
         final Future<Void> connect = natsClient.connect();
 
@@ -124,13 +270,50 @@ class SubscriptionReadStreamImplTest {
             error.set(event);
             latch.countDown();
         });
-        latch.await(10, TimeUnit.SECONDS);
+        try {
+            latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         if (error.get() != null) {
             throw new IllegalStateException(error.get());
         }
         return natsClient;
     }
-    private NatsClient getNatsClient(Vertx vertx) throws InterruptedException {
-        return getNatsClient(vertx, event -> event.printStackTrace());
+
+    private NatsStream jetStream(NatsClient natsClient) {
+        final JetStreamOptions options = JetStreamOptions.builder().build();
+        final Future<NatsStream> connect = natsClient.jetStream(options);
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicReference<NatsStream> stream = new AtomicReference<>();
+        connect.onSuccess(event -> {
+            stream.set(event);
+            latch.countDown();
+        }).onFailure(event -> {
+            error.set(event);
+            latch.countDown();
+        });
+        try {
+            latch.await(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (error.get() != null) {
+            fail();
+        }
+        return stream.get();
     }
+
+    private void closeClient(NatsClient natsClient) {
+        final CountDownLatch endLatch = new CountDownLatch(1);
+        natsClient.end().onSuccess(event -> endLatch.countDown());
+        try {
+            endLatch.await(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
 }


### PR DESCRIPTION
Started to create subscription object. 

Added fetch and iterate convenience methods to stream.

## **Added**

- Two new methods `fetch()` and `iterate()` have been added to the `NatsStream` interface. These methods allows the user to request a batch of messages from the subscription.

## **Changed**

- The method `nextMessage()` has been removed.

## **Deprecated**

- The method `pull()` has been removed. This method is no longer necessary, as the new `fetch()` method can be used to request a batch of messages from the subscription.

## **Fixed**

- A bug has been fixed in the `NatsStreamImpl` class. The bug caused the `fetch()` method to throw an exception if no messages were available in the subscription.

Overall, these changes improve the performance and usability of the `NatsStream` interface. The new `fetch()` method makes it easier for the user to retrieve messages from a subscription, and the deprecated `pull()` method has been removed.

## Preview SubscriptionReadStream

```java

        final Future<SubscriptionReadStream> subscribeFuture = natsStream.subscribe(subjectName,
                PullSubscribeOptions.builder().build());
        subscribeFuture.onSuccess(subscription -> {

                        final Future<List<NatsVertxMessage>> messageFuture = subscription.fetch(10, Duration.ofSeconds(5));
                        messageFuture.onSuccess(events -> {
                            events.forEach(NatsVertxMessage::ack);

                        }).onFailure(testContext::failNow);
                    }
                }
        ).onFailure(event ->
                {
                    event.printStackTrace();
                    testContext.failNow(event);
                }
        );
    }
```
