### PR TITLE
fix: jNATS MessageQueue API changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
 
-    implementation 'io.nats:jnats:2.17.2'
+    implementation 'io.nats:jnats:2.19.1'
     implementation("com.fasterxml.jackson.core:jackson-core:2.14.2")
     implementation("io.netty:netty-handler:4.1.97.Final")
     implementation(platform("io.vertx:vertx-stack-depchain:4.5.1"))

--- a/src/main/java/io/nats/client/impl/VertxDispatcherMessageQueue.java
+++ b/src/main/java/io/nats/client/impl/VertxDispatcherMessageQueue.java
@@ -1,6 +1,7 @@
 package io.nats.client.impl;
 
 import io.nats.client.MessageHandler;
+import io.nats.client.Options;
 import io.vertx.core.impl.ContextInternal;
 
 import java.time.Duration;
@@ -11,7 +12,11 @@ public class VertxDispatcherMessageQueue extends MessageQueue {
     private final ContextInternal context;
 
     VertxDispatcherMessageQueue(VertxDispatcher dispatcher, ContextInternal context) {
-        super(true);
+        this(dispatcher, context, Options.DEFAULT_REQUEST_CLEANUP_INTERVAL);
+    }
+
+    VertxDispatcherMessageQueue(VertxDispatcher dispatcher, ContextInternal context, Duration cleanupInterval) {
+        super(true, cleanupInterval);
         this.dispatcher = dispatcher;
         this.context = context;
     }
@@ -65,7 +70,6 @@ public class VertxDispatcherMessageQueue extends MessageQueue {
         throw new IllegalStateException("poisonTheQueue not used.");
     }
 
-    @Override
     boolean offer(NatsMessage msg) {
         throw new IllegalStateException("offer not used.");
     }


### PR DESCRIPTION
This PR follows jNATS > 2.17.4 API changes of MessageQueue so that latest jNATS library can be used

Due to the changes introduced in jNATS irt MessageQueue this PR can introduce behavioural changes at runtime.

related: #70

Solution:

Constructor chaining VertxDispatcherMessageQueue using NatsOptions.DEFAULT_REQUEST_CLEANUP_INTERVAL or user provided Duration for Cleanup Interval.
