### PR TITLE
Start 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This component provides a NATS client for reading and sending messages from/to a
 The nats-java-vertx-client is a Java client library for connecting to the NATS messaging system. It is built on top of
 the Vert.x event-driven framework and provides an asynchronous, non-blocking API for sending and receiving messages over NATS.
 
-**Current Release**: 2.2.0 &nbsp; **Current Snapshot**: 2.2.1-SNAPSHOT
+**Current Release**: 2.2.1 &nbsp; **Current Snapshot**: 2.2.2-SNAPSHOT
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.nats/nats-vertx-interface/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.nats/nats-vertx-interface)

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 }
 
-def jarVersion = "2.2.1"
+def jarVersion = "2.2.2"
 group = 'io.nats'
 
 def isRelease = System.getenv("BUILD_EVENT") == "release"
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.nats:jnats:2.21.1'
+    implementation 'io.nats:jnats:2.21.5'
     implementation("com.fasterxml.jackson.core:jackson-core:2.19.0")
     implementation("io.netty:netty-handler:4.2.1.Final")
     implementation(platform("io.vertx:vertx-stack-depchain:4.5.14"))

--- a/src/main/java/io/nats/client/impl/VertxDispatcherMessageQueue.java
+++ b/src/main/java/io/nats/client/impl/VertxDispatcherMessageQueue.java
@@ -30,7 +30,7 @@ public class VertxDispatcherMessageQueue extends MessageQueue {
     boolean push(NatsMessage msg) {
         NatsSubscription sub = msg.getNatsSubscription();
         if (sub != null && sub.isActive()) {
-            MessageHandler handler = dispatcher.subscriptionHandlers.get(sub.getSID());
+            MessageHandler handler = dispatcher.nonDefaultHandlerBySid.get(sub.getSID());
             if (handler == null) {
                 handler = dispatcher.defaultHandler;
             }


### PR DESCRIPTION
* Upgraded Nats client required minor change due to change to NatsDispatcher. This seems like a breaking change from NatsDispatcher, but the change was to a protected (non-public) variable so is not guaranteed even inside a minor version.